### PR TITLE
Fix typo (Exploit -> Export)

### DIFF
--- a/remote-backup/config.json
+++ b/remote-backup/config.json
@@ -2,7 +2,7 @@
   "name": "Remote Backup",
   "version": "4.2.6",
   "slug": "remote_backup",
-  "description": "Exploit snapshots and SCP/rsync to create remote backups to specified server",
+  "description": "Export snapshots and SCP/rsync to create remote backups to specified server",
   "url": "https://github.com/pflaugh/hassio-addons/blob/master/README.md",
   "startup": "once",
   "boot": "manual",


### PR DESCRIPTION
Fix the typo in config.json.